### PR TITLE
Simplified setup of SSLContext with OCSP while using PEM files

### DIFF
--- a/ocsp/src/main/java/io/nats/ocsp/OcspExample.java
+++ b/ocsp/src/main/java/io/nats/ocsp/OcspExample.java
@@ -5,7 +5,9 @@ import io.nats.client.Nats;
 import io.nats.client.Options;
 import nl.altindag.ssl.exception.CertificateParseException;
 import nl.altindag.ssl.exception.GenericIOException;
+import nl.altindag.ssl.util.CertificateUtils;
 import nl.altindag.ssl.util.IOUtils;
+import nl.altindag.ssl.util.KeyStoreUtils;
 import nl.altindag.ssl.util.PemUtils;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
@@ -78,13 +80,7 @@ public class OcspExample
         // that pem file. You likely will have to figure out how to load your own certificates
         // Then add the certificates to a Key Store. You will likely have a different way to make or
         // load your own Key Store
-        List<X509Certificate> certificates = loadCertificates(ocspCaCertPath());
-        KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
-        keyStore.load(null, KEY_STORE_PASSWORD.toCharArray());
-        for (X509Certificate certificate : certificates) {
-            String alias = certificate.getSubjectX500Principal().getName();
-            keyStore.setCertificateEntry(alias, certificate);
-        }
+        KeyStore keyStore = KeyStoreUtils.createTrustStore(CertificateUtils.loadCertificate(ocspCaCertPath()));
 
         // The PKIXRevocationChecker is the class that does the work of checking the revocation
         CertPathBuilder cpb = CertPathBuilder.getInstance("PKIX");


### PR DESCRIPTION
Hi @scottf 

Thank you for this repo and providing examples. I discovered this repo when you started using one of my libraries.
I was going through the examples and thanks to your code snippet I discovered that the library was not capable of easily configuring ocsp while using other utilities for example the PemUtils with OCSP. I made some changes which made this now possible with the latest release. Within your examples less custom code is needed to achieve the same result.

Please have a look, I am looking forward to get your feedback on this.