### PR TITLE
Bump GH Actions versions (Go; node12 deprecation)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,18 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18.5
+          go-version: '1.19.9'
       - name: Install Nats Server
         uses: scottf/install-nats-io-server-ubuntu@v1
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Chain of Command
         run: |
           pushd chain-of-command


### PR DESCRIPTION
Bump various GitHub Actions versions to move away from those using the deprecated node.js 12 runtime, and so remove the warnings.

Bump Golang to the latest security fixed patch-level within the same minor, and quote the string for defensiveness against version number parsing and YAML string vs version numbers.  While we're unlikely to switch to patch-level-unspecified in future, protect against mistakes by quoting, as we're doing for all repos.
